### PR TITLE
doc(install): clone + symlink install alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Copy the `./library` directory to your Ansible project and ensure your
 library = ./library
 ```
 
+Alternatively, you can clone this repo locally, and symlink the contents of the `library` folder somewhere in your [default module path](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-module-path), eg:
+
+```bash
+cd ${ANSIBLE_HOME:-~/.ansible}
+mkdir -p plugins/modules
+cd plugins/modules
+ln -s /path/to/your/local/clone/of/ansible-modules-syncthing/library/* .
+```
+
 Please note this module was tested on:
 
 * Debian Buster with Syncthing v1.0.0


### PR DESCRIPTION
Propose an alternative way of install, allowing for more flexible management of the dependency to this repo (track which version you are using, no need for copying again the `library` folder should a new version be released, etc.).