### PR TITLE
feat(facts): new syncthing_facts module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Collection of modules for [Syncthing](https://syncthing.net) management.
 
 ## Install
 
-Copy the `./library` directory to your Ansible project and ensure your
-`ansible.cfg` has this line:
+Copy the `./library` & `module_utils` directories to your Ansible project and ensure your
+`ansible.cfg` has these lines:
 
 ```ini
 [defaults]
 library = ./library
+module_utils = ./module_utils
 ```
 
 Please note this module was tested on:
@@ -30,6 +31,39 @@ See [example playbooks](./playbooks) for robust feature usage:
 
 ## Modules
 
+### Module: `syncthing_facts`
+
+Gather Syncthing facts into `ansible_facts.syncthing`:
+
+- `api_key`: API key (auto-detected if not provided)
+- `config`: config read from the API
+- `host`: API host (auto-detected if not provided)
+- `id`: device ID
+- `validate_certs`: should we validate the API TLS certificate?
+
+The auto-detection requires the module to be read with a user with read access on the Syncthing config file.
+
+Examples:
+
+```yml
+- name: Gather syncthing facts
+  syncthing_facts:
+    # Mandatory when using Syncthing's default self signed TLS certificate,
+    # this choice will be persisted in gathered facts
+    validate_certs: false
+  become: true
+  # Needed only when gathering facts using auto-detection,
+  # to ensure read acess to Syncthing's config.xml
+  become_user: syncthing
+
+- name: Use gathered facts with other syncthing modules
+  syncthing_device:
+    host: "{{ syncthing.host }}"
+    api_key: "{{ syncthing.api_key }}"
+    validate_certs: "{{ syncthing.validate_certs | bool }}"
+    # [...]
+```
+
 ### Module: `syncthing_device`
 
 Manage synced devices. Add, remove or pause devices using ID.
@@ -43,13 +77,17 @@ Examples:
     id: ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG
     name: my-device-name
 
-# Add a device to share with
+- name: Gather syncthing facts
+  syncthing_facts:
+
+# Add a device to share with, use gathered facts
 - name: Add syncthing device
   syncthing_device:
     id: ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG
     name: my-other-device
-    host: http://127.0.0.1:8384
-    api_key: aBCDeFG1h2IJKlmNopq3rs45uvwxy6Zz
+    host: "{{ syncthing.host }}"
+    api_key: "{{ syncthing.api_key }}"
+    validate_certs: "{{ syncthing.validate_certs | bool }}"
 
 # Pause an existing device
 - name: Pause syncthing device
@@ -81,7 +119,10 @@ Examples:
     devices:
       - ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG
 
-# Add a folder to share with several devices, specify host and api key
+- name: Gather syncthing facts
+  syncthing_facts:
+
+# Add a folder to share with several devices, use gathered facts
 - name: Add syncthing folder
   syncthing_folder:
     path: ~/Downloads
@@ -89,8 +130,9 @@ Examples:
     devices:
       - ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG
       - GFEDCBA-GFEDCBA-GFEDCBA-GFEDCBA-GFEDCBA-GFEDCBA-GFEDCBA-GFEDCBA
-    host: http://127.0.0.1:8384
-    api_key: aBCDeFG1h2IJKlmNopq3rs45uvwxy6Zz
+    host: "{{ syncthing.host }}"
+    api_key: "{{ syncthing.api_key }}"
+    validate_certs: "{{ syncthing.validate_certs | bool }}"
 
 # Pause an existing folder
 - name: Pause syncthing folder

--- a/library/storage/syncthing/syncthing_facts.py
+++ b/library/storage/syncthing/syncthing_facts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Rafael Bodill <justrafi at google mail>
+# Copyright: (c) 2020, Borjan Tchakaloff <first name at last name dot fr>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+module: syncthing_facts
+
+short_description: Gather Syncthing facts
+
+version_added: "2.8"
+
+description: Gather syncthing facts from Syncthing's REST API and/or XML config on the filesystem.
+
+options:
+    host:
+        description:
+            - API host to connect to, including protocole & port.
+              If not provided, will try to auto-configure from filesystem.
+        required: false
+    validate_certs:
+        description:
+            - Whether the API TLS certificate should be validated
+              (set to false when using Syncthing's default self-signed
+              certificate)
+        default: true
+    api_key:
+        description:
+            - API key to use for authentication with host.
+              If not provided, will try to auto-configure from filesystem.
+        required: false
+    config_file:
+        description:
+            - Path to the Syncthing configuration file for automatic
+              discovery (`host` & `api_key`). If not provided, will try to
+              auto-detect from standard location. Note that the running user
+              needs read access to the file.
+        required: false
+    timeout:
+        description:
+            - The socket level timeout in seconds
+        default: 30
+
+author:
+    - Mael Le Guen
+'''
+
+EXAMPLES = r'''
+- name: Gather syncthing facts
+  syncthing_facts:
+    # Mandatory when using Syncthing's default self signed TLS certificate,
+    # this choice will be persisted in gathered facts
+    validate_certs: false
+  become: true
+  # Needed only when gathering facts using auto-detection,
+  # to ensure read acess to Syncthing's config.xml
+  become_user: syncthing
+
+- name: Use gathered facts with other syncthing modules
+  syncthing_device:
+    host: "{{ syncthing.host }}"
+    api_key: "{{ syncthing.api_key }}"
+    validate_certs: "{{ syncthing.validate_certs | bool }}"
+    # [...]
+'''
+
+RETURN = r'''
+ansible_facts:
+    description: The gathered facts.
+    type: dict
+    contains:
+        syncthing:
+            description: Syncthing facts
+            type: dict
+            contains:
+                api_key:
+                    description: API key to use for authentication with host
+                    type: string
+                config:
+                    description: The full Syncthing config read from the REST api
+                    type: dict
+                host:
+                    description: API host to connect to, including protocole & port
+                    type: string
+                id:
+                    description: Syncthing device ID of this node
+                    type: string
+                validate_certs:
+                    description: Whether the API TLS certificate should be validated
+                    type: bool
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.syncthing import get_common_argument_spec, get_config
+
+def run_module():
+    module_args = get_common_argument_spec()
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    config, id = get_config(module)
+    result = {
+        "changed": False,
+        "ansible_facts": {
+            "syncthing": {
+                "api_key": module.params['api_key'],
+                "config": config,
+                "host": module.params['host'],
+                "id": id,
+                "validate_certs": module.params['validate_certs']
+            }
+        },
+    }
+
+    module.exit_json(**result)
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/syncthing.py
+++ b/module_utils/syncthing.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Rafael Bodill <justrafi at google mail>
+# Copyright: (c) 2020, Borjan Tchakaloff <first name at last name dot fr>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import os
+import json
+import platform
+from xml.etree.ElementTree import parse
+
+from ansible.module_utils.urls import fetch_url, url_argument_spec
+
+SYNCTHING_API_BASE_URI = "/rest"
+if platform.system() == 'Windows':
+    DEFAULT_ST_CONFIG_LOCATIONS = ['%localappdata%/Syncthing/config.xml']
+elif platform.system() == 'Darwin':
+    DEFAULT_ST_CONFIG_LOCATIONS = ['$HOME/Library/Application Support/Syncthing/config.xml']
+else:
+    DEFAULT_ST_CONFIG_LOCATIONS = [
+        '$HOME/.local/state/syncthing/config.xml',
+        '$HOME/.config/syncthing/config.xml', # Before syncthing 1.27.0
+    ]
+
+
+def get_common_argument_spec():
+    module_args = url_argument_spec()
+    module_args.update(dict(
+        host=dict(type='str', required=False),
+        validate_certs=dict(type='bool', default=True),
+        api_key=dict(type='str', required=False, no_log=True),
+        config_file=dict(type='str', required=False),
+        timeout=dict(type='int', default=30),
+    ))
+    return module_args
+
+# Fetch Syncthing configuration
+def get_config(module):
+    return get_data_from_rest_api(module, 'system/config')
+
+def get_data_from_rest_api(module, resource):
+    url, headers = make_headers(module, resource)
+    resp, info = fetch_url(
+        module,
+        url,
+        data=None,
+        headers=headers,
+        method='GET',
+        timeout=module.params['timeout']
+    )
+
+    if not info or info['status'] != 200:
+        result = {
+            "changed": False,
+            "response": info,
+        }
+        module.fail_json(msg='Error occured while calling host', **result)
+
+    try:
+        content = resp.read()
+    except AttributeError:
+        result = {
+            "changed": False,
+            "content": info.pop('body', ''),
+            "response": str(info),
+        }
+        module.fail_json(msg='Error occured while reading response', **result)
+
+    return json.loads(content), info.get('x-syncthing-id', None)
+
+def make_headers(module, resource):
+    if not module.params['api_key'] or not module.params['host']:
+        auto_configuration(module)
+
+    url = '{}{}/{}'.format(module.params['host'], SYNCTHING_API_BASE_URI, resource)
+    headers = {'X-Api-Key': module.params['api_key'] }
+    return url, headers
+
+def auto_configuration(module):
+    if not module.params['config_file']:
+        for location in DEFAULT_ST_CONFIG_LOCATIONS:
+            path = os.path.expandvars(location)
+            if os.path.isfile(path):
+                module.params['config_file'] = path
+                break
+        else:
+            module.fail_json(msg="Auto-configuration failed: unable to locate the config file."
+                                 " Please specify the host and API key manually.")
+    try:
+        stconfig = parse(module.params['config_file'])
+        root = stconfig.getroot()
+        gui = root.find('gui')
+
+        if not module.params['host']:
+            tls = gui.attrib.get('tls', 'false') == 'true'
+            module.params['host'] = ('https://' if tls else 'http://') + gui.find('address').text
+
+        if not module.params['api_key']:
+            module.params['api_key'] = gui.find('apikey').text
+    except Exception:
+        module.fail_json(msg="Auto-configuration failed: unable to read " + module.params['config_file'] +
+                             " Please specify the host and API key manually.")
+
+# Post the new configuration to Syncthing API
+def post_config(module, config, result):
+    url, headers = make_headers(module, 'system/config')
+    headers['Content-Type'] = 'application/json'
+
+    result['msg'] = config
+    resp, info = fetch_url(
+        module, url, data=json.dumps(config), headers=headers,
+        method='POST', timeout=module.params['timeout'])
+
+    if not info or info['status'] != 200:
+        result['response'] = str(info)
+        module.fail_json(**result)

--- a/playbooks/manage.yml
+++ b/playbooks/manage.yml
@@ -2,7 +2,6 @@
 
 - hosts: syncthing
   vars:
-    syncthing_api: 127.0.0.1:8384
     syncthing_service_user: deploy
     syncthing_folders:
       - path: /srv/data/media
@@ -22,28 +21,27 @@
         mode:  '{{ item.mode  | default("0755") }}'
       with_items: "{{ syncthing_folders }}"
 
-    - name: Get system config to grab unique id of each machine
-      uri:
-        url: "http://{{ syncthing_api }}/rest/system/config"
-        return_content: no
-        status_code: [ 200, 403 ]
-      register: syncthing_config_raw
-      check_mode: no
+    - name: Gather syncthing facts
+      syncthing_facts:
+        # Mandatory when using Syncthing's default self signed TLS certificate
+        validate_certs: false
+      become: true
+      # To ensure read acess to Syncthing's config.xml for host & API key auto-detection
+      become_user: "{{ syncthing_service_user }}"
 
     - name: Set each machine with a unique id
       set_fact:
-        syncthing_id: "{{ syncthing_config_raw.x_syncthing_id }}"
         syncthing_ids: []
 
     - name: Prepare a list of all machine ids
       set_fact:
-        syncthing_ids: "{{ syncthing_ids + [ hostvars[item].syncthing_id ] }}"
+        syncthing_ids: "{{ syncthing_ids + [ hostvars[item].ansible_facts.syncthing.id ] }}"
       when: inventory_hostname != item
       with_items: "{{ groups['syncthing'] }}"
 
     - name: Ensure syncthing devices
       syncthing_device:
-        id: "{{ hostvars[item].syncthing_id }}"
+        id: "{{ hostvars[item].ansible_facts.syncthing.id }}"
         name: "{{ item }}"
       become: yes
       become_user: "{{ syncthing_service_user }}"


### PR DESCRIPTION
- new `syncthing_facts` module to gather facts to be reused by other calls (eg host, API key & device ID)
- refactoring of duplicated code into a new `syncthing` module utils
- host auto-detection
- option not to validate self-signed TLS certificates
- syncthing >= 1.27.0 new config.xml location support